### PR TITLE
Add RAG log reflection scripts

### DIFF
--- a/RAGScripts/format_prompt.py
+++ b/RAGScripts/format_prompt.py
@@ -1,0 +1,29 @@
+from typing import Dict, List, Tuple
+
+
+def format_single_log(date: str, log: Dict) -> str:
+    status = log.get("status", {})
+    insights = log.get("insights", {})
+    return (
+        f"Date: {date}\n"
+        f"Summary: {log.get('summary', '')}\n"
+        f"Mood: {status.get('moodLevel', '')}\n"
+        f"Energy: {status.get('energyLevel', '')}\n"
+        f"Tags: {', '.join(log.get('tags', []))}\n"
+        f"Insights:\n"
+        f"- Wins: {', '.join(insights.get('wins', []))}\n"
+        f"- Losses: {', '.join(insights.get('losses', []))}\n"
+        f"- Ideas: {', '.join(insights.get('ideas', []))}\n"
+    )
+
+
+def format_prompt(question: str, logs: List[Tuple[str, Dict]]) -> str:
+    if not logs:
+        return f"User asked: {question}\n\nNo matching logs were found."
+
+    formatted_logs = "\n".join(format_single_log(date, log) for date, log in logs)
+    prompt = (
+        f"User asked: {question}\n\n"
+        f"Here are the matching logs:\n{formatted_logs}"
+    )
+    return prompt

--- a/RAGScripts/load_logs.py
+++ b/RAGScripts/load_logs.py
@@ -1,0 +1,37 @@
+import json
+import os
+from typing import Dict, Any
+
+def load_logs(directory: str = "CleanedDaily") -> Dict[str, Any]:
+    """Load all JSON logs from the given directory.
+
+    Each log is stored in a dictionary keyed by the ISO date
+    extracted from the timestamp field.
+    """
+    logs = {}
+    if not os.path.isdir(directory):
+        raise FileNotFoundError(f"Directory not found: {directory}")
+
+    for filename in os.listdir(directory):
+        if not filename.endswith(".json"):
+            continue
+        filepath = os.path.join(directory, filename)
+        try:
+            with open(filepath, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            timestamp = data.get("timestamp")
+            if timestamp:
+                date_str = timestamp.split("T")[0]
+            else:
+                # Fallback to filename without extension
+                date_str = os.path.splitext(filename)[0]
+            logs[date_str] = data
+        except (json.JSONDecodeError, OSError):
+            # Skip malformed files but continue loading others
+            continue
+    return logs
+
+if __name__ == "__main__":
+    # Simple manual test
+    logs = load_logs()
+    print(f"Loaded {len(logs)} logs")

--- a/RAGScripts/openai_client.py
+++ b/RAGScripts/openai_client.py
@@ -1,0 +1,26 @@
+import os
+from typing import Optional
+
+import openai
+
+
+SYSTEM_PROMPT = (
+    "You are a personal log reflection assistant. Only respond based on the provided data."
+)
+
+
+def query_openai(prompt_text: str, model: str = "gpt-4") -> str:
+    """Send the prompt to OpenAI's ChatCompletion API and return the response."""
+    api_key: Optional[str] = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise EnvironmentError("OPENAI_API_KEY environment variable not set")
+
+    openai.api_key = api_key
+
+    messages = [
+        {"role": "system", "content": SYSTEM_PROMPT},
+        {"role": "user", "content": prompt_text},
+    ]
+
+    response = openai.ChatCompletion.create(model=model, messages=messages)
+    return response.choices[0].message["content"].strip()

--- a/RAGScripts/rag_reflect.py
+++ b/RAGScripts/rag_reflect.py
@@ -1,0 +1,97 @@
+import os
+import re
+import sys
+from typing import List, Tuple, Dict
+
+# Ensure parent directory is on sys.path for package imports
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from RAGScripts.retrieve import (
+    get_log_by_date,
+    search_logs_by_keyword,
+    filter_logs_by_mood_below,
+)
+from RAGScripts.format_prompt import format_prompt
+from RAGScripts.openai_client import query_openai
+
+MONTH_MAP = {
+    "jan": 1,
+    "feb": 2,
+    "mar": 3,
+    "apr": 4,
+    "may": 5,
+    "jun": 6,
+    "jul": 7,
+    "aug": 8,
+    "sep": 9,
+    "oct": 10,
+    "nov": 11,
+    "dec": 12,
+}
+
+
+def _detect_date(question: str) -> str:
+    """Try to extract a date in YYYY-MM-DD from the question."""
+    match = re.search(r"(\d{1,2})[-/](\d{1,2})[-/](\d{2,4})", question)
+    if match:
+        day, month, year = match.groups()
+        year = int(year)
+        if year < 100:
+            year += 2000
+        return f"{year:04d}-{int(month):02d}-{int(day):02d}"
+
+    match = re.search(r"(\d{1,2})\s*(jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)[a-z]*\s*(\d{2,4})?",
+                       question, re.IGNORECASE)
+    if match:
+        day, month_str, year = match.groups()
+        month = MONTH_MAP[month_str[:3].lower()]
+        if year:
+            year = int(year)
+            if year < 100:
+                year += 2000
+        else:
+            year = 2025
+        return f"{year:04d}-{month:02d}-{int(day):02d}"
+    return ""
+
+
+def handle_question(question: str) -> str:
+    lower_q = question.lower()
+    logs: List[Tuple[str, Dict]] = []
+
+    date = _detect_date(question)
+    if date:
+        logs = get_log_by_date(date)
+    elif "mood" in lower_q and re.search(r"below\s*(\d+)", lower_q):
+        threshold = float(re.search(r"below\s*(\d+)", lower_q).group(1))
+        logs = filter_logs_by_mood_below(threshold)
+    elif any(kw in lower_q for kw in ["suicidal", "burnout"]):
+        for kw in ["suicidal", "burnout"]:
+            if kw in lower_q:
+                logs = search_logs_by_keyword(kw)
+                break
+    else:
+        logs = search_logs_by_keyword(question)
+
+    prompt = format_prompt(question, logs)
+    try:
+        return query_openai(prompt)
+    except Exception as e:
+        return f"Error querying language model: {e}"
+
+
+def main():
+    print("Personal Log Reflection CLI. Type 'exit' to quit.")
+    while True:
+        try:
+            question = input("> ").strip()
+        except (EOFError, KeyboardInterrupt):
+            break
+        if not question or question.lower() in {"exit", "quit"}:
+            break
+        answer = handle_question(question)
+        print(answer)
+
+
+if __name__ == "__main__":
+    main()

--- a/RAGScripts/retrieve.py
+++ b/RAGScripts/retrieve.py
@@ -1,0 +1,62 @@
+import re
+from difflib import SequenceMatcher
+from typing import Any, Dict, List, Tuple
+
+from RAGScripts.load_logs import load_logs
+
+# Load logs once at import time
+LOGS: Dict[str, Any] = load_logs()
+
+
+def get_log_by_date(date_str: str) -> List[Tuple[str, Dict[str, Any]]]:
+    """Return log(s) exactly matching the given ISO date string."""
+    data = LOGS.get(date_str)
+    return [(date_str, data)] if data else []
+
+
+def _fuzzy_contains(needle: str, haystack: str, threshold: float = 0.6) -> bool:
+    haystack = haystack.lower()
+    needle = needle.lower()
+    if needle in haystack:
+        return True
+    ratio = SequenceMatcher(None, needle, haystack).ratio()
+    return ratio >= threshold
+
+
+def search_logs_by_keyword(keyword: str) -> List[Tuple[str, Dict[str, Any]]]:
+    """Search logs for a keyword across summary, insights, and tags."""
+    results = []
+    for date, log in LOGS.items():
+        parts = [log.get("summary", "")]
+        insights = log.get("insights", {})
+        for key in ("wins", "losses", "ideas"):
+            parts.extend(insights.get(key, []))
+        parts.extend(log.get("tags", []))
+        text = " ".join(parts)
+        if _fuzzy_contains(keyword, text):
+            results.append((date, log))
+    return results
+
+
+def filter_logs_by_mood_below(threshold: float) -> List[Tuple[str, Dict[str, Any]]]:
+    """Return logs where moodLevel is below the given threshold."""
+    results = []
+    for date, log in LOGS.items():
+        try:
+            mood = float(log.get("status", {}).get("moodLevel", 0))
+            if mood < threshold:
+                results.append((date, log))
+        except (TypeError, ValueError):
+            continue
+    return results
+
+
+def search_logs_by_tag(tag: str) -> List[Tuple[str, Dict[str, Any]]]:
+    """Return logs that contain the given tag (fuzzy match)."""
+    results = []
+    for date, log in LOGS.items():
+        for existing_tag in log.get("tags", []):
+            if _fuzzy_contains(tag, existing_tag):
+                results.append((date, log))
+                break
+    return results


### PR DESCRIPTION
## Summary
- create `RAGScripts` package for the reflection CLI
- support loading logs, retrieval helpers and fuzzy search
- format logs for prompts and send to OpenAI API
- add interactive `rag_reflect.py` command line tool

## Testing
- `python -m py_compile $(git ls-files "RAGScripts/*.py")`
- `python RAGScripts/rag_reflect.py <<'EOF'
What happened on 1 June 2025?
exit
EOF` (fails without OPENAI_API_KEY)


------
https://chatgpt.com/codex/tasks/task_e_6883d3c36a788327b3aa91e9dc4136b3